### PR TITLE
Update skills section to match CV

### DIFF
--- a/src/lib/components/sections/Skills.svelte
+++ b/src/lib/components/sections/Skills.svelte
@@ -77,30 +77,10 @@
 					<span class="w-3 h-3 rounded-full bg-dotnet-light"></span>
 					Practices & Patterns
 				</h3>
-				<div class="flex flex-wrap gap-3">
-					{#each skills.practices as practice}
-						<span
-							class="px-4 py-2 bg-bg-deep rounded-lg text-sm font-medium border border-border hover:border-dotnet/50 transition-colors"
-						>
-							{practice.name}
-						</span>
+				<div class="space-y-4">
+					{#each skills.practices as skill}
+						<SkillBar {skill} animated={inView} />
 					{/each}
-					<span
-						class="px-4 py-2 bg-bg-deep rounded-lg text-sm font-medium border border-border hover:border-dotnet/50 transition-colors"
-						>Unit Testing</span
-					>
-					<span
-						class="px-4 py-2 bg-bg-deep rounded-lg text-sm font-medium border border-border hover:border-dotnet/50 transition-colors"
-						>Integration Testing</span
-					>
-					<span
-						class="px-4 py-2 bg-bg-deep rounded-lg text-sm font-medium border border-border hover:border-dotnet/50 transition-colors"
-						>REST API Design</span
-					>
-					<span
-						class="px-4 py-2 bg-bg-deep rounded-lg text-sm font-medium border border-border hover:border-dotnet/50 transition-colors"
-						>Microservices</span
-					>
 				</div>
 			</div>
 		</div>

--- a/src/lib/data/skills.ts
+++ b/src/lib/data/skills.ts
@@ -4,25 +4,38 @@ export const skills: SkillCategory = {
 	languages: [
 		{ name: 'C#', level: 95, color: '#239120' },
 		{ name: 'TypeScript', level: 85, color: '#3178c6' },
-		{ name: 'SQL', level: 90, color: '#f29111' },
+		{ name: 'SQL (PostgreSQL/MSSQL)', level: 90, color: '#f29111' },
+		{ name: 'Redis', level: 90, color: '#dc382d' },
+		{ name: 'MongoDB', level: 70, color: '#47a248' },
 		{ name: 'CLI', level: 80, color: '#5391fe' }
 	],
 	frameworks: [
 		{ name: 'ASP.NET Core', level: 95, color: '#512bd4' },
 		{ name: 'Entity Framework', level: 90, color: '#512bd4' },
-		{ name: 'Svelte', level: 90, color: '#512bd4' },
-		{ name: 'Vue', level: 80, color: '#0078d4' }
+		{ name: 'Svelte/SvelteKit', level: 90, color: '#ff3e00' },
+		{ name: 'Vue/Nuxt', level: 80, color: '#42b883' },
+		{ name: 'Angular', level: 75, color: '#dd0031' },
+		{ name: 'React', level: 60, color: '#61dafb' }
 	],
 	tools: [
 		{ name: 'Claude Code', level: 95, color: '#0078d4' },
 		{ name: 'Docker', level: 80, color: '#2496ed' },
-		{ name: 'Jetbrains IDEs', level: 90, color: '#cc2927' },
-		{ name: 'Git', level: 95, color: '#f05032' }
+		{ name: 'JetBrains IDEs', level: 90, color: '#cc2927' },
+		{ name: 'Git', level: 95, color: '#f05032' },
+		{ name: 'Terraform', level: 80, color: '#7b42bc' },
+		{ name: 'AWS', level: 85, color: '#ff9900' },
+		{ name: 'Azure', level: 70, color: '#0078d4' },
+		{ name: 'OpenTelemetry', level: 70, color: '#f5a800' }
 	],
 	practices: [
-		{ name: 'Clean Architecture', level: 90 },
-		{ name: 'Hexagonal Design', level: 85 },
-		{ name: 'Domain-Driven Design', level: 85 },
-		{ name: 'CI/CD Pipelines', level: 95 }
+		{ name: 'Clean Architecture', level: 90, color: '#512bd4' },
+		{ name: 'Hexagonal Design', level: 85, color: '#512bd4' },
+		{ name: 'Domain-Driven Design', level: 85, color: '#512bd4' },
+		{ name: 'CI/CD Pipelines', level: 95, color: '#0078d4' },
+		{ name: 'Microservices', level: 85, color: '#0078d4' },
+		{ name: 'REST API Design', level: 90, color: '#0078d4' },
+		{ name: 'AGILE/Scrum', level: 85, color: '#239120' },
+		{ name: 'OIDC/OAUTH', level: 90, color: '#239120' },
+		{ name: 'Testing (Unit & Integration)', level: 85, color: '#239120' }
 	]
 };


### PR DESCRIPTION
## Summary
- Add missing technologies across all categories: Redis, MongoDB, Angular, React, Terraform, AWS, Azure, OpenTelemetry, AGILE/Scrum, OIDC/OAUTH, and Testing
- Rename existing entries to match CV naming (SQL → SQL (PostgreSQL/MSSQL), Svelte → Svelte/SvelteKit, Vue → Vue/Nuxt)
- Move hard-coded practice tags (Unit Testing, Integration Testing, REST API Design, Microservices) into the data file
- Switch Practices & Patterns card from tag layout to skill bars for visual consistency with the other three cards

## Test plan
- [x] `npm run check` passes with no errors
- [x] `npm run build` succeeds
- [x] Visually inspect all four skill cards — bars render and animate on scroll
- [x] Verify Practices & Patterns card now shows skill bars instead of tags